### PR TITLE
[MM-27459] Changing smallest supported db instance class to sync with PostgreSQL supported instance types

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 // DBInstanceClasses is used to store the available DB Instance Classes. The classes are specified with size order.
 var DBInstanceClasses = []string{
-	"db.t3.small",
+	"db.t3.medium",
 	"db.r5.large",
 	"db.r5.xlarge",
 	"db.r5.2xlarge",


### PR DESCRIPTION
#### Summary
Changing smallest supported db instance class to sync with PostgreSQL supported instance types.

### Depends on 
Depending on Database Factory release: https://github.com/mattermost/mattermost-cloud-database-factory/pull/9

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27459

#### Release Note

```release-note
- Changing smallest supported db instance class to sync with PostgreSQL supported instance types.
```
