### PR TITLE
Fix circle to docker that supports buildx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,11 @@ jobs:
       name: default
     steps:
     - checkout
-    - setup_remote_docker
-    - run: make build-image
+    - setup_remote_docker:
+        version: 20.10.7
+    - run: |
+        export DOCKER_CLI_EXPERIMENTAL=enabled
+        make build-image
     - run: make push-image-pr
 
 
@@ -39,8 +42,11 @@ jobs:
       name: default
     steps:
     - checkout
-    - setup_remote_docker
-    - run: make build-image
+    - setup_remote_docker:
+        version: 20.10.7
+    - run: |
+        export DOCKER_CLI_EXPERIMENTAL=enabled
+        make build-image
     - run: make push-image
 
   scan-image:


### PR DESCRIPTION
Issue: MM-40777

#### Summary
Fix circle to use remote docker that supports buildx

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix circle to use remote docker that supports buildx
```
