### PR TITLE
Export TAG

### DIFF
--- a/scripts/push-image.sh
+++ b/scripts/push-image.sh
@@ -8,10 +8,10 @@ cat BASH_ENV | while read line; do
 done
 if [ -z "${CIRCLE_TAG:-}" ]; then
   echo "Pushing latest for $CIRCLE_BRANCH..."
-  TAG=latest
+  export TAG=latest
 else
   echo "Pushing release $CIRCLE_TAG..."
-  TAG="$CIRCLE_TAG"
+  export TAG="$CIRCLE_TAG"
 fi
 echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
 make build-image-with-tag


### PR DESCRIPTION
Without exporting doesn't work on make command's context
Issue:

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
FIx bug on pushing latest image TAG environment variable.
```
